### PR TITLE
Rename docker image

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Default values for configuration
-IMAGE_NAME="ros2-testing-workshop-roscon-es-25"
+IMAGE_NAME="ekumenlabs/ros2-testing-workshop-roscon-es-25"
 ROS_DISTRO="jazzy"
 PLATFORM="linux/amd64"
 TAG="${ROS_DISTRO}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 USERNAME=$(whoami)
-IMAGE_NAME="ros2-testing-workshop-roscon-es-25"
+IMAGE_NAME="ekumenlabs/ros2-testing-workshop-roscon-es-25"
 ROS_DISTRO="jazzy"
 TAG="${ROS_DISTRO}"
 CONTAINER_NAME="ros2-testing-worshop-roscon-es-25-container"


### PR DESCRIPTION
## What this PR does

Renames the docker image to `ekumenlabs/ros2-testing-workshop-roscon-es-25` to match image name in [dockerhub](https://hub.docker.com/r/ekumenlabs/ros2-testing-workshop-roscon-es-25/tags).

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## How to test

Steps to reproduce / test the changes:

1. Build the docker image with the new name:

```bash
./docker/build.sh
```

2. Check the name is now `ekumenlabs/ros2-testing-workshop-roscon-es-25` with `docker image ls` command.
3. Run the compose:

```bash
./docker/run.sh
```

## Checklist

- [x] I have signed my commits (`git commit -s`) or added Signed-off-by to existing commits.
- [ ] I added/updated tests (if applicable)
- [ ] I updated documentation (if applicable)

## Related issues

* Relates to https://github.com/ekumenlabs/ros2_testing_workshop_roscon_es_25/issues/2
