### PR TITLE
Improve Module 3 exercise

### DIFF
--- a/modules/module_3/src/laser_detector_node.cpp
+++ b/modules/module_3/src/laser_detector_node.cpp
@@ -48,11 +48,11 @@ LaserDetectorNode::LaserDetectorNode(const rclcpp::NodeOptions& options)
   }
 
   // Publishers
-  obstacle_pub_ = this->create_publisher<std_msgs::msg::Bool>("obstacle_detection", 10);
+  obstacle_pub_ = this->create_publisher<std_msgs::msg::Bool>("obstacle_detections", 10);
 
   // Subscribers
   scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
-      "scans", rclcpp::SensorDataQoS(),
+      "scan", rclcpp::SensorDataQoS(),
       std::bind(&LaserDetectorNode::scan_callback, this, std::placeholders::_1));
 
   RCLCPP_INFO(this->get_logger(), "LaserDetectorNode initialized");


### PR DESCRIPTION
## What this PR does

In module 3, avoid misleading constructor test failure when parameter declare and get have intentional typos to force the user to fix node parameter definitions. 

```bash
3: [==========] Running 7 tests from 2 test suites.
3: [----------] Global test environment set-up.
3: [----------] 4 tests from TestLaserDetectorNodeConstructor
3: [ RUN      ] TestLaserDetectorNodeConstructor.CreatingANodeDoesNotThrow
3: /home/developer/ws/src/module_3/test/test_laser_detector_node.cpp:84: Failure
3: Expected: { const LaserDetectorNode dut(default_node_options_); } doesn't throw an exception.
3:   Actual: it throws rclcpp::exceptions::ParameterNotDeclaredException with description "footprint_radius".
3: 
3: [  FAILED  ] TestLaserDetectorNodeConstructor.CreatingANodeDoesNotThrow (30 ms)
3: [ RUN      ] TestLaserDetectorNodeConstructor.EvaluateConstructorDeclaresParameters
3: unknown file: Failure
3: C++ exception with description "footprint_radius" thrown in the test body.
3: 
3: [  FAILED  ] TestLaserDetectorNodeConstructor.EvaluateConstructorDeclaresParameters (17 ms)
3: [ RUN      ] TestLaserDetectorNodeConstructor.EvaluateConstructorReadsParameters
3: unknown file: Failure
3: C++ exception with description "footprint_radius" thrown in the test body.
3: 
3: [  FAILED  ] TestLaserDetectorNodeConstructor.EvaluateConstructorReadsParameters (17 ms)
```

To solve this, we define the typo in the same parameter for both declare and get functions, obtaining a meaningful error rather than an uncontrolled exception:

```bash
3: [ RUN      ] TestLaserDetectorNodeConstructor.EvaluateConstructorDeclaresParameters
3: [INFO] [1762367206.043342909] [laser_detector_node]: LaserDetectorNode initialized
3: /home/developer/ws/src/module_3/test/test_laser_detector_node.cpp:97: Failure
3: Value of: dut.has_parameter("min_points")
3:   Actual: false
3: Expected: true
3: 
3: [  FAILED  ] TestLaserDetectorNodeConstructor.EvaluateConstructorDeclaresParameters (15 ms)
```

Also, fix intentional typo in subscriber and place it on the publisher. The test covers the publisher and the test for the subscriber is on the user side. This is a more natural exercise flow.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Documentation

## How to test

Steps to reproduce / test the changes:

1. Apply solutions to module 2.
2. Build module 3
3. Test module 3
4. Repeat steps 2 and 3 incrementally as you solve the bugs and complete the tests.

## Checklist

- [ ] I have signed my commits (`git commit -s`) or added Signed-off-by to existing commits.
- [ ] I added/updated tests (if applicable)
- [ ] I updated documentation (if applicable)

## Related issues

N/A
