### PR TITLE
Fix docker scripts incompatibilities with non-GPU and graphics

### DIFF
--- a/docker/join.sh
+++ b/docker/join.sh
@@ -41,11 +41,5 @@ if [[ ${#ARGS[@]} -eq 0 ]]; then
   ARGS=("bash")
 fi
 
-# Allow GUI applications
-xhost +
-
 # Join a running container
 docker exec -it "$CONTAINER_NAME" "${ARGS[@]}"
-
-# Disallow GUI applications after container exits
-xhost -


### PR DESCRIPTION
## What this PR does

This PR removes the GUI and GPU support when running docker. The GPU setup is incorrect but since we do not need to run any simulation or graphic tool, it's better to simplify and just remove the related flags and environment values.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Documentation

## How to test

Steps to reproduce / test the changes:

1. Run `docker.sh` and ensure it does not throw any error.
2. Run `join.sh` and ensure it does not throw any error.

## Checklist

- [ ] I have signed my commits (`git commit -s`) or added Signed-off-by to existing commits.
- [ ] I added/updated tests (if applicable)
- [ ] I updated documentation (if applicable)

## Related issues

* Solves https://github.com/Ekumen-OS/ros2_testing_workshop_roscon_es_25/issues/43